### PR TITLE
Fixed issue that spawned enemies only in town

### DIFF
--- a/NPCs/GradiusEnemy.cs
+++ b/NPCs/GradiusEnemy.cs
@@ -134,7 +134,7 @@ namespace ChensGradiusMod.NPCs
     protected static bool UsualSpawnConditions(NPCSpawnInfo spawnInfo)
     {
       return Main.hardMode && !spawnInfo.invasion &&
-             (spawnInfo.playerSafe || spawnInfo.playerInTown);
+             !(spawnInfo.playerSafe || spawnInfo.playerInTown);
     }
 
     protected virtual int FrameTick { get; set; } = 0;


### PR DESCRIPTION
Initially, a missing ! caused the mod to spawn enemies during hardmode outside of invasions, but only if the player was safe or in town.